### PR TITLE
Update front page with logo

### DIFF
--- a/_layouts/custom-home.html
+++ b/_layouts/custom-home.html
@@ -5,7 +5,10 @@ layout: default
 
 <!-- Hero Text -->
 <section class="custom-hero wrapper">
-    <h1>Welcome to Gap Tap Support</h1>
+    <h1>
+        <img src="/assets/images/gap-tap-logo.png" alt="Gap Tap Logo" style="height: 2em; vertical-align: middle;" />
+        Welcome to <span class="visually-hidden">Gap Tap</span> Support
+    </h1>
 
 </section>
 


### PR DESCRIPTION
Replace "Gap Tap" text with the logo on the front page.

---

[Open in Web](https://www.cursor.com/agents?id=bc-21f06674-dd3f-43b4-871d-5b13294c55cc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-21f06674-dd3f-43b4-871d-5b13294c55cc)